### PR TITLE
updated formatting to fix the Note block

### DIFF
--- a/Instructions/Labs/01-lakehouse.md
+++ b/Instructions/Labs/01-lakehouse.md
@@ -50,8 +50,9 @@ Now that you have a workspace, it's time to switch to the *Data engineering* exp
 Fabric provides multiple ways to load data into the lakehouse, including built-in support for pipelines that copy data external sources and data flows (Gen 2) that you can define using visual tools based on Power Query. However one of the simplest ways to ingest small amounts of data is to upload files or folders from your local computer (or lab VM if applicable).
 
 1. Download the **sales.csv** file from [https://raw.githubusercontent.com/MicrosoftLearning/dp-data/main/sales.csv](https://raw.githubusercontent.com/MicrosoftLearning/dp-data/main/sales.csv), saving it as **sales.csv** on your local computer (or lab VM if applicable).
-   > **Note**: To download the file, open a new tab in the browser and paste in the URL.
-   > Right click anywhere on the page containing the data and select **Save as** to save the page as a CSV file.
+
+   > **Note**: To download the file, open a new tab in the browser and paste in the URL. Right click anywhere on the page containing the data and select **Save as** to save the page as a CSV file.
+
 2. Return to the web browser tab containing your lakehouse, and in the **...** menu for the **Files** folder in the **Lakehouse explorer** pane, select **New subfolder**, and create a subfolder named **data**.
 3. In the **...** menu for the new **data** folder, select **Upload** and **Upload file**, and then upload the **sales.csv** file from your local computer (or lab VM if applicable).
 4. After the file has been uploaded, select the **Files/data** folder and verify that the **sales.csv** file has been uploaded, as shown here:


### PR DESCRIPTION
## Lab/Demo: 01

In skillable environment, the "Note" block bleeds into the numbered list and seems to affect also the screenshot.

![image](https://github.com/MicrosoftLearning/mslearn-fabric/assets/110993710/a8121c2c-2e49-48a8-9876-03f3bd0bfb40)
