### PR TITLE
Corrected indentation issue in code block under Step 10 which caused it to be rendered as plain text.

### DIFF
--- a/Instructions/Labs/02-analyze-spark.md
+++ b/Instructions/Labs/02-analyze-spark.md
@@ -157,9 +157,9 @@ Now you're ready to run code that loads the data into a *dataframe*. Dataframes 
 10. The dataframe includes only the data from the **2019.csv** file. Modify the code so that the file path uses a \* wildcard to read the sales order data from all of the files in the **orders** folder:
 
     ```python
-   from pyspark.sql.types import *
+    from pyspark.sql.types import *
 
-   orderSchema = StructType([
+    orderSchema = StructType([
        StructField("SalesOrderNumber", StringType()),
        StructField("SalesOrderLineNumber", IntegerType()),
        StructField("OrderDate", DateType()),
@@ -171,8 +171,8 @@ Now you're ready to run code that loads the data into a *dataframe*. Dataframes 
        StructField("Tax", FloatType())
        ])
 
-   df = spark.read.format("csv").schema(orderSchema).load("Files/orders/*.csv")
-   display(df)
+    df = spark.read.format("csv").schema(orderSchema).load("Files/orders/*.csv")
+    display(df)
     ```
 
 11. Run the modified code cell and review the output, which should now include sales for 2019, 2020, and 2021.


### PR DESCRIPTION
Corrected indentation of the code lines under "Load Data into a Dataframe" step 10, where the line indentation of the code lines were one space too few. This resulted in the code block in step 10 to instead show as plain text, and the step numbering for step 11 to incorrectly restart as step 1.

# Module: 00
## Lab/Demo: 02

Fixes # .

Changes proposed in this pull request:

- Correct markdown for code block under "Load Data into a Dataframe" step 10