### PR TITLE
Lab 03 - Remove angle brackets from example

### DIFF
--- a/Instructions/Labs/03-delta-lake.md
+++ b/Instructions/Labs/03-delta-lake.md
@@ -99,7 +99,7 @@ You can also create *external* tables for which the schema metadata is defined i
 1. Add another new code cell, and add the following code to it:
 
     ```python
-   df.write.format("delta").saveAsTable("external_products", path="<abfs_path>/external_products")
+   df.write.format("delta").saveAsTable("external_products", path="abfs_path/external_products")
     ```
 
 2. In the **Lakehouse explorer** pane, in the **...** menu for the **Files** folder, select **Copy ABFS path**.
@@ -108,7 +108,7 @@ You can also create *external* tables for which the schema metadata is defined i
 
     *abfss://workspace@tenant-onelake.dfs.fabric.microsoft.com/lakehousename.Lakehouse/Files*
 
-3. In the code you entered into the code cell, replace **<abfs_path>** with the path you copied to the clipboard so that the code saves the dataframe as an external table with data files in a folder named **external_products** in your **Files** folder location. The full path should look similar to this:
+3. In the code you entered into the code cell, replace **abfs_path** with the path you copied to the clipboard so that the code saves the dataframe as an external table with data files in a folder named **external_products** in your **Files** folder location. The full path should look similar to this:
 
     *abfss://workspace@tenant-onelake.dfs.fabric.microsoft.com/lakehousename.Lakehouse/Files/external_products*
 


### PR DESCRIPTION
# Module: Work with Delta Lake tables in Microsoft Fabric
## Lab/Demo: Use delta tables in Apache Spark

Changes proposed in this pull request:
- The <abfs_path> content on the page looks correct in markdown, but when converted to HTML, this is treated like a tag. So the 'abfs_path' text doesn't appear in the lab instructions online.

![image](https://github.com/MicrosoftLearning/mslearn-fabric/assets/139177104/f503559e-3dfa-488c-bf3e-1f66cadb6c47)

Note: I'm not an MCT, just a user that's completed the awesome training. Please let me know if I should submit this as an issue instead.