### PR TITLE
Update 06a-data-warehouse-load.md

### DIFF
--- a/Instructions/Labs/06a-data-warehouse-load.md
+++ b/Instructions/Labs/06a-data-warehouse-load.md
@@ -102,11 +102,6 @@ Let's create the fact tables and dimensions for the Sales data. You'll also crea
         
     ALTER TABLE Sales.Dim_Item add CONSTRAINT PK_Dim_Item PRIMARY KEY NONCLUSTERED (ItemID) NOT ENFORCED
     GO
-    
-    CREATE VIEW [Sales].[Staging_Sales]
-    AS
-        SELECT * FROM [ExternalData].[dbo].[staging_sales];
-    GO
     ```
 
     > **Important:** In a data warehouse, foreign key constraints are not always necessary at the table level. While foreign key constraints can help ensure data integrity, they can also add overhead to the ETL (Extract, Transform, Load) process and slow down data loading. The decision to use foreign key constraints in a data warehouse should be based on a careful consideration of the trade-offs between data integrity and performance.
@@ -183,7 +178,7 @@ Let's run some analytical queries to validate the data in the warehouse.
     SELECT c.CustomerName, SUM(s.UnitPrice * s.Quantity) AS TotalSales
     FROM Sales.Fact_Sales s
     JOIN Sales.Dim_Customer c
-    ON s.SalesOrderNumber = c.SalesOrderNumber
+    ON s.CustomerID = c.CustomerID
     WHERE YEAR(s.OrderDate) = 2021
     GROUP BY c.CustomerName
     ORDER BY TotalSales DESC;


### PR DESCRIPTION
Adjustment in the first SQL section that contains the code for the second section (create view).

In the "Run analytical queries" session, in the first code "SalesOrderNumber" is being used in the join when it should be "CustomerID".

# Module: 00
## Lab/Demo: 06a

Fixes # .

Changes proposed in this pull request:

-
-
-