### PR TITLE
Update 06a-data-warehouse-load.md

### DIFF
--- a/Instructions/Labs/06a-data-warehouse-load.md
+++ b/Instructions/Labs/06a-data-warehouse-load.md
@@ -183,7 +183,7 @@ Let's run some analytical queries to validate the data in the warehouse.
     SELECT c.CustomerName, SUM(s.UnitPrice * s.Quantity) AS TotalSales
     FROM Sales.Fact_Sales s
     JOIN Sales.Dim_Customer c
-    ON s.SalesOrderNumber = c.SalesOrderNumber
+    ON s.CustomerID = c.CustomerID
     WHERE YEAR(s.OrderDate) = 2021
     GROUP BY c.CustomerName
     ORDER BY TotalSales DESC;


### PR DESCRIPTION
The first query from section "Run analytical queries" is wrong:

    ```sql
    SELECT c.CustomerName, SUM(s.UnitPrice * s.Quantity) AS TotalSales
    FROM Sales.Fact_Sales s
    JOIN Sales.Dim_Customer c
    ON s.SalesOrderNumber = c.SalesOrderNumber
    WHERE YEAR(s.OrderDate) = 2021
    GROUP BY c.CustomerName
    ORDER BY TotalSales DESC;
    ```
The line "ON s.SalesOrderNumber = c.SalesOrderNumber" should be changed with "ON s.CustomerID = c.CustomerID" as the Fact_Sales and Dim_Customer are related on CustomerID not on SalesOrderNumber

## Lab: 06a

Fixes # .

Changes proposed in this pull request:

-
-
-