### PR TITLE
Update 02-analyze-spark.md

### DIFF
--- a/Instructions/Labs/02-analyze-spark.md
+++ b/Instructions/Labs/02-analyze-spark.md
@@ -148,7 +148,7 @@ Now you're ready to run code that loads the data into a *dataframe*. Dataframes 
 
 1. The dataframe includes only the data from the **2019.csv** file. Modify the code so that the file path uses a \* wildcard to read the sales order data from all of the files in the **orders** folder:
 
-    ```python
+    ```Python
     from pyspark.sql.types import *
 
     orderSchema = StructType([


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 01

Fixes #123

Changes proposed in this pull request:

- make the codeblock follow the same typing as the rest of the document
- If not it adds spaces in front of the codeblock throwing off proper spacing
-