### PR TITLE
Lab07 Select Local File Clarification and Fixed Typo

### DIFF
--- a/Instructions/Labs/07-real-time-Intelligence.md
+++ b/Instructions/Labs/07-real-time-Intelligence.md
@@ -44,7 +44,7 @@ Kusto query language (KQL) is used to query static or streaming data in a table 
 
    The Eventhouse is used to group and manage your databases across projects. An empty KQL database is automatically created with the eventhouse's name.
    
-3. When the new database has been created, select the option to get data from **Local File**. Then use the wizard to import the data into a new table by selecting the following options:
+3. Once the new database has been created, select it from the list on the left under KQL Databases. Then select the option to get data from **Local File**. Use the wizard to import the data into a new table by selecting the following options:
     - **Destination**:
         - **Database**: *The database you created is already selected*
         - **Table**: *Create a new table named* **sales** by clicking on the + sign to the left of ***New table***
@@ -59,7 +59,7 @@ Kusto query language (KQL) is used to query static or streaming data in a table 
 
         ![New table wizard step three](./Images/import-wizard-local-file-3.png?raw=true)
 
-        - In this screen you'll see that your column headings are in teh first row although the system detected them, we still need to move the slider above these lines **First row is column header** in order to get keep from getting any errors.
+        - In this screen you'll see that your column headings are in the first row although the system detected them, we still need to move the slider above these lines **First row is column header** in order to get keep from getting any errors.
         
         ![New table wizard step four](./Images/import-wizard-local-file-4.png?raw=true)
 


### PR DESCRIPTION
# Module: Get started with Real-Time Intelligence in Microsoft Fabric
## Lab/Demo: 07

Task: Create a KQL database
Step: 3
Fixed typo and clarified instructions for selecting local file 

Changes proposed in this pull request:

- Step 3, bullet point 4: "In this screen you’ll see that your column headings are in teh first row although the system
detected them, we still need to move the slider above these lines First row is column header in order to get keep from getting any errors." -> has a typo fixed teh to the 
-  Step 3: Currently the instructions say once the database has been created select Local File. However, this is confusing because after creating the Eventhouse you are in the system overview section which doesn't have the add local file option -> Should be instruction to click on your database under the KQL databases and then select local file