### PR TITLE
Patch - Use correct alias names for variables referring to the "gold" tables

### DIFF
--- a/Instructions/Labs/03b-medallion-lakehouse.md
+++ b/Instructions/Labs/03b-medallion-lakehouse.md
@@ -436,7 +436,7 @@ Note that you could have done all of this in a single notebook, but for the purp
 12. **Add another code block** to create the **product_silver** dataframe.
   
     ```python
-    from pyspark.sql.functions import col, split, lit
+    from pyspark.sql.functions import col, split, lit, when
     
     # Create product_silver dataframe
     


### PR DESCRIPTION
The alias names used for the variables linked to the gold tables were  called "silver". This is confusing, and it appeared like a copy paste from the section "Transform data for Silver". So, change the alias to "gold" and also the corresponding joins.