### PR TITLE
KQL query to bin the result within 5 second window

### DIFF
--- a/Instructions/Labs/09-real-time-analytics-eventstream.md
+++ b/Instructions/Labs/09-real-time-analytics-eventstream.md
@@ -166,7 +166,7 @@ Now you can query the bicycle data that has been transformed and loaded into a t
     ```kql
     ['bikes-by-street']
     | summarize TotalBikes = sum(tolong(SUM_No_Bikes)) by bin(Window_End_Time, 5s), Street
-    | sort by Window_End_Time asc, Street asc
+    | sort by Window_End_Time desc, Street asc
     ```
 
 1. Select the modified query and run it.

--- a/Instructions/Labs/09-real-time-analytics-eventstream.md
+++ b/Instructions/Labs/09-real-time-analytics-eventstream.md
@@ -165,6 +165,7 @@ Now you can query the bicycle data that has been transformed and loaded into a t
 
     ```kql
     ['bikes-by-street']
+    | where Window_End_Time >= ago(5s)
     | summarize TotalBikes = sum(tolong(SUM_No_Bikes)) by Window_End_Time, Street
     | sort by Window_End_Time desc , Street asc
     ```

--- a/Instructions/Labs/09-real-time-analytics-eventstream.md
+++ b/Instructions/Labs/09-real-time-analytics-eventstream.md
@@ -165,9 +165,8 @@ Now you can query the bicycle data that has been transformed and loaded into a t
 
     ```kql
     ['bikes-by-street']
-    | where Window_End_Time >= ago(5s)
-    | summarize TotalBikes = sum(tolong(SUM_No_Bikes)) by Window_End_Time, Street
-    | sort by Window_End_Time desc , Street asc
+    | summarize TotalBikes = sum(tolong(SUM_No_Bikes)) by bin(Window_End_Time, 5s), Street
+    | sort by Window_End_Time asc, Street asc
     ```
 
 1. Select the modified query and run it.


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 09

Fixes # .

Changes proposed in this pull request: In the lab description, Instruction explicitly mentioned to window the results in 5 seconds. Instead it summarizes the total number of bikes per street based on the Window_End_Time without binning the data into 5 second intervals. Added a bin function to match the window expectation of the lab instructions.

- Update the KQL query to match binning of 5 second interval
