### PR TITLE
Updated Power BI usage in labs 1, 6, & 16

### DIFF
--- a/Instructions/Labs/01-lakehouse.md
+++ b/Instructions/Labs/01-lakehouse.md
@@ -130,42 +130,6 @@ While many data professionals are familiar with SQL, data analysts with Power BI
 
     ![Screenshot of a Visual query with results.](./Images/visual-query-results.png)
 
-## Create a report
-
-The tables in your lakehouse are automatically added to a default semantic model for reporting with Power BI.
-
-
-1. In the toolbar, select **Model layouts**. The data model schema for the semantic model is shown.
-
-    ![Screenshot of model layouts](./Images/lakehouse-model-layouts.png)
-
-    > **Note 1**: In this exercise, the semantic model consists of a single table. In a real-world scenario, you would likely create multiple tables in your lakehouse, each of which would be included in the model. You could then define relationships between these tables in the model.
-    
-    > **Note 2**: The views **frequently_run_queries**, **long_running_queries**, **exec_sessions_history**, and **exec_requests_history** are part of the **queryinsights** schema automatically created by Fabric. It is a feature that provides a holistic view of historical query activity on the SQL analytics endpoint. Since this feature is out of the scope of this exercise, those views should be ignored for now.
-
-2. In the menu ribbon, select the **Reporting** tab. Then select **New report**. Your current page will change to a report designer view.
-
-    ![Screenshot of the report designer.](./Images/report-designer.png)
-
-3. In the **Data** pane on the right, expand the **sales** table. Then select the following fields:
-    - **Item**
-    - **Quantity**
-
-    A table visualization is added to the report:
-
-    ![Screenshot of a report containing a table.](./Images/table-visualization.png)
-
-4. Hide the **Data** and **Filters** panes to create more space. Then ensure the table visualization is selected and in the **Visualizations** pane, change the visualization to a **Clustered bar chart** and resize it as shown here.
-
-    ![Screenshot of a report containing a clustered bar chart.](./Images/clustered-bar-chart.png)
-
-5. On the **File** menu, select **Save**. Then save the report as `Item Sales Report` in the workspace you created previously.
-6. Now, in the hub menu bar on the left, select your workspace to verify that it contains the following items:
-    - Your lakehouse.
-    - The SQL analytics endpoint for your lakehouse.
-    - A default semantic model for the tables in your lakehouse.
-    - The **Item Sales Report** report.
-
 ## Clean up resources
 
 In this exercise, you have created a lakehouse and imported data into it. You've seen how a lakehouse consists of files and tables stored in a OneLake data store. The managed tables can be queried using SQL, and are included in a default semantic model to support data visualizations.

--- a/Instructions/Labs/06-data-warehouse.md
+++ b/Instructions/Labs/06-data-warehouse.md
@@ -176,7 +176,7 @@ A data warehouse in Microsoft Fabric has many of the same capabilities you may b
    ORDER BY CalendarYear, MonthOfYear, SalesRegion;
     ```
 
-### Create a visual query
+## Create a visual query
 
 Instead of writing SQL code, you can use the graphical query designer to query the tables in your data warehouse. This experience is similar to Power Query online, where you can create data transformation steps with no code. For more complex tasks, you can use Power Query's M (Mashup) language.
 
@@ -199,48 +199,9 @@ Instead of writing SQL code, you can use the graphical query designer to query t
 
 1. From here, you can analyze the results of this single query by selecting **Visualize results** or **Download Excel file**. You can now see exactly what the manager was asking for, so we don't need to analyze the results further.
 
-### Visualize your data
-
-You can easily visualize the data in either a single query, or in your data warehouse. Before you visualize, hide columns and/or tables that aren't friendly to report designers.
-
-1. Select the **Model layouts** button. 
-
-1. Hide the following columns in your Fact and Dimension tables that are not necessary to create a report. Note that this does not remove the columns from the model, it simply hides them from view on the report canvas.
-   1. FactSalesOrder
-      - **SalesOrderDateKey**
-      - **CustomerKey**
-      - **ProductKey**
-   1. DimCustomer
-      - **CustomerKey**
-      - **CustomerAltKey**
-   1. DimDate
-      - **DateKey**
-      - **DateAltKey**
-   1. DimProduct
-      - **ProductKey**
-      - **ProductAltKey** 
-
-1. Now you're ready to build a report and make this dataset available to others. On the Reporting menu, select **New report**. This will open a new window, where you can create a Power BI report.
-
-1. In the **Data** pane, expand **FactSalesOrder**. Note that the columns you hid are no longer visible. 
-
-1. Select **SalesTotal**. This will add the column to the **Report canvas**. Because the column is a numeric value, the default visual is a **column chart**.
-1. Ensure that the column chart on the canvas is active (with a gray border and handles), and then select **Category** from the **DimProduct** table to add a category to your column chart.
-1. In the **Visualizations** pane, change the chart type from a column chart to a **clustered bar chart**. Then resize the chart as necessary to ensure that the categories are readable.
-
-    ![Screenshot of the Visualizations pane with the bar chart selected.](./Images/visualizations-pane.png)
-
-1. In the **Visualizations** pane, select the **Format your visual** tab and in the **General** sub-tab, in the **Title** section, change the **Text** to **Total Sales by Category**.
-
-1. In the **File** menu, select **Save**. Then save the report as **Sales Report** in the workspace you created previously.
-
-1. In the menu hub on the left, navigate back to the workspace. Notice that you now have three items saved in your workspace: your data warehouse, its default semantic model, and the report you created.
-
-    ![Screenshot of the workspace with the three items listed.](./Images/workspace-items.png)
-
 ## Clean up resources
 
-In this exercise, you have created a data warehouse that contains multiple tables. You used SQL to insert data into the tables and query them. and also used the visual query tool. Finally, you enhanced the data model for the data warehouse's default dataset and used it as the source for a report.
+In this exercise, you have created a data warehouse that contains multiple tables. You used SQL to insert data into the tables and queried tables using T-SQL and the visual query tool. Finally, you enhanced the data model for the data warehouse's default dataset for downstream analytics and reporting.
 
 If you've finished exploring your data warehouse, you can delete the workspace you created for this exercise.
 

--- a/Instructions/Labs/16-create-reusable-power-bi-assets.md
+++ b/Instructions/Labs/16-create-reusable-power-bi-assets.md
@@ -6,7 +6,7 @@ lab:
 
 # Create reusable Power BI assets
 
-In this exercise you'll create reusable assets to support semantic model and report development. These assets include Power BI Project and Template files and shared semantic models. At the end, you'll explore the lineage view how these items relate to each other in the Power BI service.
+In this exercis,e you'll create reusable assets to support semantic model and report development. These assets include Power BI Project and Template files and shared semantic models. At the end, lineage view shows how these items relate to each other in the Power BI service.
 
    > Note: this exercise doesn't require a Fabric license and can be completed in a Power BI or Microsoft Fabric environment.
 
@@ -19,27 +19,6 @@ Before you can start this exercise, you need to open a web browser and enter the
 `https://github.com/MicrosoftLearning/mslearn-fabric/raw/refs/heads/main/Allfiles/Labs/16b/16-reusable-assets.zip`
 
 Extract the folder to the **C:\Users\Student\Downloads\16-reusable-assets** folder.
-
-## Publish a report to the Power BI service
-
-In this task, you use an existing report to create a shared semantic model for reuse to develop other reports.
-
-1. From a web browser, navigate and sign in to the Fabric service: [https://app.fabric.microsoft.com](https://app.fabric.microsoft.com)
-1. Navigate to the Power BI experience and create a new workspace with a unique name of your choice.
-
-    ![Screenshot of the Workspace pane highlighting the + New workspace button.](./Images/power-bi-new-workspace.png)
-
-1. In the top ribbon in your new workspace, select **Upload > Browse**.
-1. In the new File Explorer dialog box, navigate to and select the starter *.pbix* file and select **Open** to upload.
-1. Notice how you now have two different items in the workspace with the same name:
-
-    - Report
-    - Semantic model
-
-1. Open the report and notice the color theme used. *You'll change this in a later task.*
-1. You can now close your web browser.
-
-> Power BI *.pbix* files contain both the semantic model and report visuals. When you publish reports to the service, these items are separated. You'll see this separation again later.
 
 ## Create a new Power BI project
 
@@ -219,26 +198,23 @@ In this task, you'll create a template file so you can share a lightweight file 
 
 > Now you have a template with a consistent theme without any pre-loaded data.
 
-## Publish and explore your assets
+### Review final state
 
-In this task, you'll publish your Power BI Project file and look at the related items using Lineage view in the service.
+In the following screenshot, you've created your Power BI Project file and published it to a workspace. You've then navigated to the workspace in the Power BI service and switched to the **lineage view** to see how your new report depends on other data sources.
 
-> Important: We created a local DirectQuery model when we added the HTML data source. Published reports require a gateway to access the on-premises data, so you will receive an error. This doesn't affect the value of this task, but might be confusing.
+From left to right, the following items are visible:
 
-1. In your Power BI Project file, select **Publish**.
-1. **Save** your file, if prompted.
-1. **Don't upgrade** the *PBIR* version, if prompted.
-1. Select the workspace you created at the start of this exercise.
-1. Select **Open 'YourReport.*.pbip*' in Power BI** when you get the message that the file was published, but disconnected.
+- Data sources: 2 text/csv files and a SQL server connection.
+- 16-Starter-Sales Analysis semantic model, which is connected to the data sources.
+- 16-Starter-Sales Analysis report, which is connected to the 16-Starter-Sales Analysis semantic model.
+- My new report semantic model, which is connected to the 16-Starter-Sales Analysis semantic model.
+- My new report report, which is connected to the My new report semantic model.
 
-    ![Screenshot of the message that the file was published, but disconnected.](./Images/power-bi-published-disconnected-message.png)
+> When semantic models relate to other semantic models, it's known as **chaining**. In this lab, the starter semantic model is chained to the newly created semantic model, enabling its reuse for a specialized purpose.
 
-1. Once you are in your workspace, you can see the previous semantic model and report, and your new semantic model and report.
-1. In the right corner below Workspace settings, select **Lineage view** to see how your new report depends on other data sources.
+![Screenshot of the lineage view with a database and two text files connecting to a single semantic model from our starter file. That same semantic model connects to the starter file report and has a new semantic model connected to the new report.](./Images/power-bi-lineage-view.png)
 
-    ![Screenshot of the lineage view with a database and two text files connecting to a single semantic model from our starter file. That same semantic model connects to the starter file report and has a new semantic model connected to the new report.](./Images/power-bi-lineage-view.png)
 
-> When semantic models relate to other semantic models, it's known as chaining. In this lab, the starter semantic model is chained to the newly created semantic model, enabling its reuse for a specialized purpose.
 
 ## Clean up
 


### PR DESCRIPTION
These changes remove the dependency for larger Fabric SKUs and/or Power BI Pro/PPU licenses to complete labs. 

- Lab 1 has the "Create Power BI report" step removed.
- Lab 6 has the "Create Power BI report" step removed.
- Lab 16 has the "Publish and explore" step replaced with "Review final state" step. 