### PR TITLE
Update 03b-medallion-lakehouse.md

### DIFF
--- a/Instructions/Labs/03b-medallion-lakehouse.md
+++ b/Instructions/Labs/03b-medallion-lakehouse.md
@@ -83,7 +83,7 @@ Now that you have some data in the bronze layer of your lakehouse, you can use a
        ])
     
    # Import all files from bronze folder of lakehouse
-   df = spark.read.format("csv").option("header", "true").schema(orderSchema).load("Files/bronze/*.csv")
+   df = spark.read.format("csv").option("header", "false").schema(orderSchema).load("Files/bronze/*.csv")
     
    # Display the first 10 rows of the dataframe to preview your data
    display(df.head(10))


### PR DESCRIPTION
The csv files for this exercise do not have header rows.

# Module: mslearn-fabric
## Lab/Demo: 03b-medallion-lakehouse

Fixes # .
This PR fixes that the dataframe used throughout the exercise misses the first record of all three csv files loaded.

Changes proposed in this pull request:
- Change 'true' to 'false' when loading the csv files into the dataframe.
