### PR TITLE
Update lakehouse creation instructions

### DIFF
--- a/Instructions/Labs/03-delta-lake.md
+++ b/Instructions/Labs/03-delta-lake.md
@@ -28,7 +28,7 @@ Before working with data in Fabric, create a workspace in a tenant with the Fabr
 
 Now that you have a workspace, it's time to create a data lakehouse for your data.
 
-1. On the menu bar on the left, select **Create**. In the *New* page, under the *Data Engineering* section, select **Lakehouse**. Give it a unique name of your choice.
+1. On the menu bar on the left, select **Create**. In the *New* page, under the *Data Engineering* section, select **Lakehouse**. Give it a unique name of your choice. Make sure the "Lakehouse schemas" option is disabled.
 
     >**Note**: If the **Create** option is not pinned to the sidebar, you need to select the ellipsis (**...**) option first.
 


### PR DESCRIPTION
Added instruction to disable 'Lakehouse schemas' option when creating a lakehouse.

## Instructions/Lab: 03-delta-lake.md

Changes proposed in this pull request:

If the "Lakehouse schema" option is enabled, it will cause an error when creating external tables in the section: "2- In a new code cell, paste the ABFS path. Add the following code, using cut and paste to insert the abfs_path into the correct place in the code:"