### PR TITLE
Update 03b-medallion-lakehouse.md

### DIFF
--- a/Instructions/Labs/03b-medallion-lakehouse.md
+++ b/Instructions/Labs/03b-medallion-lakehouse.md
@@ -24,11 +24,6 @@ Before working with data in Fabric, create a workspace with the Fabric trial ena
 
     ![Screenshot of an empty workspace in Fabric.](./Images/new-workspace.png)
 
-1. Navigate to the workspace settings and verify that the **Data model settings** preview feature is enabled. This will enable you to create relationships between tables in your lakehouse using a Power BI semantic model.
-
-    ![Screenshot of the workspace settings page in Fabric.](./Images/workspace-settings.png)
-
-    > **Note**: You may need to refresh the browser tab after enabling the preview feature.
 
 ## Create a lakehouse and upload data to bronze layer
 


### PR DESCRIPTION

The latest version of Microsoft Fabric no longer provides an option to enable the "Data model settings" preview feature in workspace settings. This step is deprecated and its presence in the documentation led to confusion for users who could not find the setting.

Removed the obsolete instruction from the "Create a workspace" section to reflect the current product experience. No other steps in the lab are affected, and all downstream functionality including semantic model creation and table relationships remains valid without this step.

Streamlining the instructions avoids confusion and ensures alignment with the current Fabric interface

# Module: Organize a Fabric lakehouse using medallion architecture design
## Lab/Demo: 3b

##Fixes 
Remove obsolete step to enable Data model settings preview in workspace creation.

##Changes proposed in this pull request: 

Remove obsolete step to enable Data model settings preview in workspace creation.