### PR TITLE
Add lab exercise order for DP-700, DP-601, DP-602, and DP-603

### DIFF
--- a/_data/lab-metadata.yml
+++ b/_data/lab-metadata.yml
@@ -59,10 +59,28 @@ courses:
       - 19b-govern-analytics-data.md
   - id: DP-601
     name: Implement a Lakehouse with Microsoft Fabric
+    order:
+      - 01-lakehouse.md
+      - 02-analyze-spark.md
+      - 03-delta-lake.md
+      - 05-dataflows-gen2.md
+      - 04-ingest-pipeline.md
   - id: DP-602
     name: Implement a data warehouse with Microsoft Fabric
+    order:
+      - 06-data-warehouse.md
+      - 06a-data-warehouse-load.md
+      - 06b-data-warehouse-query.md
+      - 06c-monitor-data-warehouse.md
+      - 06d-secure-data-warehouse.md
   - id: DP-603
     name: Implement Real-Time Intelligence with Microsoft Fabric
+    order:
+      - 07-real-time-Intelligence.md
+      - 09-real-time-analytics-eventstream.md
+      - 12-query-data-in-kql-database.md
+      - 13-real-time-dashboards.md
+      - 11-data-activator.md
   - id: DP-604
     name: Implement a data science and machine learning solution for AI with Microsoft Fabric
   - id: DP-3029


### PR DESCRIPTION
Adds explicit `order:` arrays to `_data/lab-metadata.yml` for four courses, so the GitHub Pages course view lists labs in curriculum sequence rather than alphabetical order.

## Changes

| Course | Labs in order |
|--------|--------------|
| DP-700 | 01-lakehouse → 02-analyze-spark → 03-delta-lake → 05-dataflows-gen2 → 04-ingest-pipeline → 03b-medallion-lakehouse → 07-real-time-Intelligence → 09-real-time-analytics-eventstream → 12-query-data-in-kql-database → 13-real-time-dashboards → 11-data-activator → 06-data-warehouse → 06a-data-warehouse-load → 06c-monitor-data-warehouse → 06d-secure-data-warehouse → 21-implement-cicd → 18-monitor-hub → 19-secure-data-access |
| DP-601 | 01-lakehouse → 02-analyze-spark → 03-delta-lake → 05-dataflows-gen2 → 04-ingest-pipeline |
| DP-602 | 06-data-warehouse → 06a-data-warehouse-load → 06b-data-warehouse-query → 06c-monitor-data-warehouse → 06d-secure-data-warehouse |
| DP-603 | 07-real-time-Intelligence → 09-real-time-analytics-eventstream → 12-query-data-in-kql-database → 13-real-time-dashboards → 11-data-activator |