### PR TITLE
Add lab exercise order for DP-604 and DP-3029

### DIFF
--- a/_data/lab-metadata.yml
+++ b/_data/lab-metadata.yml
@@ -91,3 +91,8 @@ courses:
       - 08d-data-science-batch.md
   - id: DP-3029
     name: Work smarter with Copilot in Microsoft Fabric
+    order:
+      - 22a-copilot-fabric-dataflow-gen2.md
+      - 22b-copilot-fabric-notebooks.md
+      - 22c-copilot-fabric-data-warehouse.md
+      - 22d-copilot-fabric-data-agents.md

--- a/_data/lab-metadata.yml
+++ b/_data/lab-metadata.yml
@@ -59,10 +59,28 @@ courses:
       - 19b-govern-analytics-data.md
   - id: DP-601
     name: Implement a Lakehouse with Microsoft Fabric
+    order:
+      - 01-lakehouse.md
+      - 02-analyze-spark.md
+      - 03-delta-lake.md
+      - 05-dataflows-gen2.md
+      - 04-ingest-pipeline.md
   - id: DP-602
     name: Implement a data warehouse with Microsoft Fabric
+    order:
+      - 06-data-warehouse.md
+      - 06a-data-warehouse-load.md
+      - 06b-data-warehouse-query.md
+      - 06c-monitor-data-warehouse.md
+      - 06d-secure-data-warehouse.md
   - id: DP-603
     name: Implement Real-Time Intelligence with Microsoft Fabric
+    order:
+      - 07-real-time-Intelligence.md
+      - 09-real-time-analytics-eventstream.md
+      - 12-query-data-in-kql-database.md
+      - 13-real-time-dashboards.md
+      - 11-data-activator.md
   - id: DP-604
     name: Implement a data science and machine learning solution for AI with Microsoft Fabric
   - id: DP-3029

--- a/_data/lab-metadata.yml
+++ b/_data/lab-metadata.yml
@@ -83,5 +83,11 @@ courses:
       - 11-data-activator.md
   - id: DP-604
     name: Implement a data science and machine learning solution for AI with Microsoft Fabric
+    order:
+      - 08-data-science-get-started.md
+      - 08a-data-science-explore-data.md
+      - 08b-data-science-preprocess-data-wrangler.md
+      - 08c-data-science-train.md
+      - 08d-data-science-batch.md
   - id: DP-3029
     name: Work smarter with Copilot in Microsoft Fabric


### PR DESCRIPTION
Adds explicit `order:` arrays to `_data/lab-metadata.yml` for two additional courses.

## Changes

| Course | Labs in order |
|--------|--------------|
| DP-604 | 08-data-science-get-started → 08a-data-science-explore-data → 08b-data-science-preprocess-data-wrangler → 08c-data-science-train → 08d-data-science-batch |
| DP-3029 | 22a-copilot-fabric-dataflow-gen2 → 22b-copilot-fabric-notebooks → 22c-copilot-fabric-data-warehouse → 22d-copilot-fabric-data-agents |