### PR TITLE
Fix 26b: correct image path casing (./images/ -> ./Images/)

### DIFF
--- a/Instructions/Labs/26b-transform-data-dataflows.md
+++ b/Instructions/Labs/26b-transform-data-dataflows.md
@@ -186,7 +186,7 @@ Publishing makes the dataflow available for scheduled refreshes and team collabo
 
 1. Select **Save and run** to publish the updated dataflow. Wait for the refresh to complete, then navigate back to your lakehouse and verify the `Unit Price` column now shows consistent two-decimal formatting.
 
-![Screenshot of the transformed orders table.](./images/dataflow-transformed-table.png)
+![Screenshot of the transformed orders table.](./Images/dataflow-transformed-table.png)
 
 ## Try it with Copilot (Optional)
 


### PR DESCRIPTION
Fixes broken screenshot in `26b-transform-data-dataflows.md` at Task: Publish and Verify Results, Step 8.

The markdown referenced `./images/dataflow-transformed-table.png` (lowercase `i`) but the actual folder is `Images` (uppercase `I`). On case-sensitive filesystems this prevents the image from rendering.

Closes #401