### PR TITLE
Fix #403: mark second-user validation steps as Optional in secure data warehouse lab

### DIFF
--- a/Instructions/Labs/06d-secure-data-warehouse.md
+++ b/Instructions/Labs/06d-secure-data-warehouse.md
@@ -77,7 +77,7 @@ Dynamic data masking rules are applied on individual columns at the table level 
 
 3. Then, in the **Explorer** pane, expand **Schemas** > **dbo** > **Tables** and verify that the **Customers** table has been created. The `SELECT` statement returns unmasked data for you because as the workspace creator, you're a member of the Workspace Admin role which can see unmasked data.
 
-    >**Note**: If you connect as a test user that's a member of the **Viewer** workspace role and run a `SELECT` statement on the **Customers** table, you'll see the following results for the masked data.
+    > **Optional**: If you connect as a test user that's a member of the **Viewer** workspace role and run a `SELECT` statement on the **Customers** table, you'll see the following results for the masked data.
    
     ![Screenshot of the Customers table with masked data.](./Images/masked-table.png)
  
@@ -147,7 +147,7 @@ Row-level security (RLS) can be used to limit access to rows based on the identi
 6. Use the **&#9655; Run** button to run the SQL script
 7. Then, in the **Explorer** pane, expand **Schemas** > **rls** > **Functions** > **Table-valued Functions**, and verify that the function has been created.
 
-    > **Note**: If you connect as the user you replaced `<username1>@<your_domain>.com` with, and run a `SELECT` statement on the **Sales** table, you'll see the following results for row-level security.
+    > **Optional**: If you connect as the user you replaced `<username1>@<your_domain>.com` with, and run a `SELECT` statement on the **Sales** table, you'll see the following results for row-level security.
 
     ![Screenshot of the Sales table with RLS.](./Images/rls-table.png)
 
@@ -179,7 +179,7 @@ Column-level security allows you to designate which users can access specific co
    DENY SELECT ON dbo.Orders (CreditCard) TO [<username1>@<your_domain>.com];
     ```
 
-    > **Note**: If you connect as the user you replaced `<username1>@<your_domain>.com` with, and run a `SELECT` statement on the **Orders** table, you'll see the following results for column-level security.
+    > **Optional**: If you connect as the user you replaced `<username1>@<your_domain>.com` with, and run a `SELECT` statement on the **Orders** table, you'll see the following results for column-level security.
 
     ![Screenshot of the Orders table query with error.](./Images/cls-table.png)
 
@@ -225,7 +225,7 @@ Fabric has a permissions model that allows you to control access to data at the 
    GRANT EXECUTE on dbo.sp_PrintMessage to [<username1>@<your_domain>.com];
     ```
 
-    > **Note**: If you connect as the user you replaced `<username1>@<your_domain>.com` with, execute the stored procedure and run a `SELECT` statement on the **Parts** table, you'll see the following results for granular permissions.
+    > **Optional**: If you connect as the user you replaced `<username1>@<your_domain>.com` with, execute the stored procedure and run a `SELECT` statement on the **Parts** table, you'll see the following results for granular permissions.
 
     ![Screenshot of the Parts table query with error.](./Images/grant-deny-table.png)
 


### PR DESCRIPTION
Fixes #403

Changes to `06d-secure-data-warehouse.md`:
- Changed 4 `> **Note**:` callouts (one in each security section: dynamic data masking, row-level security, column-level security, and granular permissions) to `> **Optional**:` so learners without a second account can clearly identify which steps they can skip.