### PR TITLE
Static roles must be deleted before creating dynamic roles in the enforcing semantic model security lab

### DIFF
--- a/Instructions/Labs/17-enforce-model-security.md
+++ b/Instructions/Labs/17-enforce-model-security.md
@@ -105,6 +105,10 @@ In this task, you confirm that each role restricts the report to its assigned re
 
 Static roles work, but they don't scale. Every new region requires a new role definition, and any change means updating and republishing the semantic model. For 11 Adventure Works regions, that's 11 roles to create and maintain—and the number grows with the business.
 
+## Clean up resources
+
+Delete the static roles `Australia` and `Canada` created in this lab before proceeding to the next step.
+
 ## Add the Salesperson table
 
 Dynamic RLS requires a mapping table that links each user identity to a sales territory. In this section, you import the `Salesperson` table from a CSV file, prepare it in Power Query, and configure the relationship so security filters propagate correctly.


### PR DESCRIPTION
# Module: Enforce semantic model security

## Lab/Demo: Allfiles/Labs/17/17-enforce-model-security.md

Fixes #

When starting the Dynamic RLS lab without deleting the static roles created in the static RLS lab, Power BI displays an error and does not allow "Apply security filter in both directions".

Changes proposed in this pull request:

- Include the following line requesting to delete the resources created in the previous lab:
"Delete the static roles 'Australia' and 'Canada' created in this lab before proceeding to the next step."
