### PR TITLE
Fix open issues #420, #426, #427

### DIFF
--- a/Instructions/Labs/15-design-semantic-model-scale.md
+++ b/Instructions/Labs/15-design-semantic-model-scale.md
@@ -22,7 +22,7 @@ In this exercise, you design a semantic model for scale in the Microsoft Fabric 
 - Create a semantic model that connects to lakehouse data through Direct Lake.
 - Design star schema relationships with appropriate filter direction and referential integrity.
 - Create a calculation group for time intelligence across multiple measures.
-- Configure settings for scale, including query scale-out and OneLake integration.
+- Configure settings for scale, including query scale-out.
 
 This lab takes approximately **30** minutes to complete.
 
@@ -303,9 +303,6 @@ In this task, you configure workspace-level settings that prepare the model for 
 
     > With query scale-out enabled, Fabric can create read-only replicas of your model so that multiple users running reports simultaneously don't compete for the same resources. This is critical when dashboards are shared across large teams. Direct Lake models already have large semantic model storage format enabled (a prerequisite), so this setting is ready to use immediately.
 
-1. Expand the **OneLake integration** section. Toggle **OneLake integration** to **On**.
-
-    > With OneLake integration, the data in your semantic model becomes accessible as Delta tables in OneLake. This means data engineers can consume the same curated data in notebooks, pipelines, or other Fabric items without duplicating it, keeping the model as the single source of truth.
 
 ## Validate the model with a report
 

--- a/Instructions/Labs/25-discover-onelake.md
+++ b/Instructions/Labs/25-discover-onelake.md
@@ -85,9 +85,9 @@ Now that you have data in your lakehouse, you can explore how to discover it thr
 
 1. At the top of the page, select the Fabric icon to return to the Fabric home page.
 
-1. In the left navigation pane, select the **OneLake catalog** icon.
+1. In the left navigation pane, select the **OneLake catalog** icon. In the catalog, select the **Explore** tab and filter by **Data items** if it isn't already selected.
 
-    ![Screenshot showing the OneLake catalog with various data assets listed.](./Images/onelake-catalog.png)
+    ![Screenshot showing the OneLake catalog with various data assets listed.](./Images/onelake-catalog-explore.png)
 
 1. In the catalog, you see various item types including lakehouses, warehouses, semantic models, and reports. Browse the list to find your **salesdata** lakehouse (or whatever name you chose).
 

--- a/Instructions/Labs/25-discover-onelake.md
+++ b/Instructions/Labs/25-discover-onelake.md
@@ -51,7 +51,7 @@ Now that you have a workspace, it's time to create a lakehouse and populate it w
 
     > **Note**: To download the file, open a new tab in the browser and paste in the URL. Right-click anywhere on the page and select **Save as** to save it as a CSV file.
 
-1. In your workspace, select **+ New item**, and then select **Lakehouse**. Give it a name of your choice (for example, _sales-data_).
+1. In your workspace, select **+ New item**, and then select **Lakehouse**. Give it a name of your choice (for example, _salesdata_).
 
     After a minute or so, a new lakehouse with empty **Tables** and **Files** folders will be created.
 
@@ -89,7 +89,7 @@ Now that you have data in your lakehouse, you can explore how to discover it thr
 
     ![Screenshot showing the OneLake catalog with various data assets listed.](./Images/onelake-catalog.png)
 
-1. In the catalog, you see various item types including lakehouses, warehouses, semantic models, and reports. Browse the list to find your **sales_data** lakehouse (or whatever name you chose).
+1. In the catalog, you see various item types including lakehouses, warehouses, semantic models, and reports. Browse the list to find your **salesdata** lakehouse (or whatever name you chose).
 
     > **Note**: Depending on what else is in your trial environment, you may see other items in the catalog. The catalog respects access permissions, so you only see items you have permission to access.
 
@@ -107,7 +107,7 @@ Now that you have data in your lakehouse, you can explore how to discover it thr
 
 After discovering a data asset in the catalog, the next step is to explore its structure. Understanding the tables, columns, and data types helps you determine whether the data meets your needs.
 
-1. From the catalog, select your **sales_data** lakehouse to open it.
+1. From the catalog, select your **salesdata** lakehouse to open it.
 
 1. In the **Explorer** pane on the left, expand the **Tables** folder to see the **sales** table you created earlier.
 
@@ -141,9 +141,9 @@ Shortcuts let you reference data from other workspaces without copying it, provi
 
     ![Screenshot showing shortcut creation dialog with OneLake selected.](./Images/onelake-shortcut-options.png)
 
-1. In the workspace list, select the workspace containing your original **sales_data** lakehouse (for example, _Data-Engineering_).
+1. In the workspace list, select the workspace containing your original **salesdata** lakehouse (for example, _Data-Engineering_).
 
-1. Select the **sales_data** lakehouse, then select the **Tables** folder.
+1. Select the **salesdata** lakehouse, then select the **Tables** folder.
 
 1. Select the **sales** table, and then select **Next**.
 


### PR DESCRIPTION
Addresses three open issues with targeted fixes:

## Changes

### Lab 15 - Design semantic model for scale (Fixes #420)
- Removed the OneLake integration toggle step, which is unnecessary for Direct Lake models since tables already exist in OneLake
- Updated the learning objective to remove the OneLake integration mention

### Lab 25 - Discover and connect to data in OneLake (Fixes #426)
- Changed example lakehouse name from `sales-data` to `salesdata` across all references (hyphens are not allowed in lakehouse names)

### Lab 25 - Discover and connect to data in OneLake (Fixes #427)
- Fixed broken screenshot reference (`onelake-catalog.png` → `onelake-catalog-explore.png`)
- Added instruction to select the Explore tab and filter by Data items, since the catalog may default to a different filter

## Reviewer notes
- Please verify the `onelake-catalog-explore.png` screenshot renders correctly