### PR TITLE
Remove DAX sharing instructions for Copilot

### DIFF
--- a/Instructions/Labs/30-prepare-model-ai.md
+++ b/Instructions/Labs/30-prepare-model-ai.md
@@ -83,10 +83,6 @@ Hiding technical fields helps Copilot focus on business-relevant data and produc
 
    Deselected fields include surrogate keys (`CustomerKey`, `ProductKey`), sort helper columns (`Day (Sort Order)`, `Month (Sort Order)`), ETL metadata (`LoadDate`, `SourceSystem`), and internal identifiers (`SalesOrderLineNumber`). Deselecting `LoadDate` also removes its auto-generated Date Hierarchy, which is expected — the dedicated `Date` table handles time-based analysis.
 
-1. In the Prep for AI dialog, select **Settings** from the left navigation.
-
-1. Turn on **Share DAX expressions with Copilot**. This allows Copilot to read the underlying DAX logic in your measures, improving its ability to choose the correct measure and explain calculations.
-
 ## Add AI instructions
 
 Table names and field descriptions don't always capture your organization's business rules and terminology. In this section, you write AI instructions that provide Copilot with business context, including key terminology, analysis preferences, and data scope.


### PR DESCRIPTION
Removed instructions for enabling DAX sharing with Copilot in the AI preparation steps.

This section of prep data for AI doesn't exist (at least in the June 2026 version of desktop)

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-